### PR TITLE
Support fast i/o for Bls12-381 G1Affine points.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,11 +28,11 @@ commands:
       - run:
           name: Test (<< parameters.target >>)
           command: TARGET=<< parameters.target >> cargo test
-          no_output_timeout: 15m
+          no_output_timeout: 30m
       - run:
           name: Test serde (<< parameters.target >>)
           command: TARGET=<< parameters.target >> cargo test --features serde
-          no_output_timeout: 15m
+          no_output_timeout: 30m
 
 jobs:
   cargo_fetch:


### PR DESCRIPTION
Add support for fast read/write of Bls12-381 `G1Affine` points. The point is speed and simplicity, so to keep things simple I am encoding the `infinity` field as a full byte rather than trying to stash it in an unused bit. This has the unintentional but somewhat useful side effect (for downstream logistical purposes) of making it easier to distinguish this output from that of a `G1Uncompressed` point by size of the output.