### PR TITLE
Add constructors for G1Compressed/G2Compressed

### DIFF
--- a/src/bls12_381/ec/g1.rs
+++ b/src/bls12_381/ec/g1.rs
@@ -193,8 +193,8 @@ impl fmt::Debug for G1Compressed {
     }
 }
 
-impl From<[u8; 48]> for G1Compressed {
-    fn from(original: [u8; 48]) -> Self {
+impl G1Compressed {
+    fn from_bytes_unchecked(original: [u8; 48]) -> Self {
         Self(original)
     }
 }
@@ -918,13 +918,14 @@ mod tests {
     use super::super::util::check_g_prime;
 
     #[test]
-    fn g1_compressed_constructor() {
+    fn g1_compressed_from_bytes_unchecked() {
         let data: [u8; 48] = [
             134, 143, 0, 94, 184, 230, 228, 202, 10, 71, 200, 167, 124, 234, 165, 48, 154, 71, 151,
             138, 124, 113, 188, 92, 206, 150, 54, 107, 93, 122, 86, 153, 55, 197, 41, 238, 218,
             102, 199, 41, 55, 132, 169, 64, 40, 1, 175, 49,
         ];
-        let _compressed = G1Compressed::from(data);
+        let compressed = G1Compressed::from_bytes_unchecked(data);
+        assert_eq!(&compressed.0[..], &data[..]);
     }
 
     #[test]

--- a/src/bls12_381/ec/g1.rs
+++ b/src/bls12_381/ec/g1.rs
@@ -193,6 +193,12 @@ impl fmt::Debug for G1Compressed {
     }
 }
 
+impl From<[u8; 48]> for G1Compressed {
+    fn from(original: [u8; 48]) -> Self {
+        Self(original)
+    }
+}
+
 impl EncodedPoint for G1Compressed {
     type Affine = G1Affine;
 
@@ -910,6 +916,16 @@ mod tests {
     use super::*;
 
     use super::super::util::check_g_prime;
+
+    #[test]
+    fn g1_compressed_constructor() {
+        let data: [u8; 48] = [
+            134, 143, 0, 94, 184, 230, 228, 202, 10, 71, 200, 167, 124, 234, 165, 48, 154, 71, 151,
+            138, 124, 113, 188, 92, 206, 150, 54, 107, 93, 122, 86, 153, 55, 197, 41, 238, 218,
+            102, 199, 41, 55, 132, 169, 64, 40, 1, 175, 49,
+        ];
+        let _compressed = G1Compressed::from(data);
+    }
 
     #[test]
     fn g1_generator() {

--- a/src/bls12_381/ec/g1.rs
+++ b/src/bls12_381/ec/g1.rs
@@ -182,6 +182,31 @@ impl EncodedPoint for G1Uncompressed {
     }
 }
 
+/// A struct holding the data of a compressed serialization of a [G1Affine].
+/// Use this to encode or decode [G1Affine]s using the compressed encoding.
+///
+/// # Examples
+///
+/// Encoding:
+///
+/// ```
+/// # use groupy::{CurveAffine, EncodedPoint};
+/// # use paired::bls12_381::{G1Affine};
+/// # let p = G1Affine::zero();
+/// use paired::bls12_381::G1Compressed;
+///
+/// let bytes = G1Compressed::from_affine(p).as_ref();
+/// ```
+///
+/// Decoding:
+///
+/// ```
+/// # use groupy::{EncodedPoint};
+/// use paired::bls12_381::G1Compressed;
+///
+/// let bytes: [u8; 48] = [134, 143, 0, 94, 184, 230, 228, 202, 10, 71, 200, 167, 124, 234, 165, 48, 154, 71, 151, 138, 124, 113, 188, 92, 206, 150, 54, 107, 93, 122, 86, 153, 55, 197, 41, 238, 218, 102, 199, 41, 55, 132, 169, 64, 40, 1, 175, 49];
+/// let p = G1Compressed::from_bytes_unchecked(bytes).into_affine().unwrap();
+/// ```
 #[derive(Copy, Clone)]
 pub struct G1Compressed([u8; 48]);
 
@@ -194,7 +219,9 @@ impl fmt::Debug for G1Compressed {
 }
 
 impl G1Compressed {
-    fn from_bytes_unchecked(original: [u8; 48]) -> Self {
+    /// Creates an instance from raw bytes.
+    /// The input is not checked to contain a valid point.
+    pub fn from_bytes_unchecked(original: [u8; 48]) -> Self {
         Self(original)
     }
 }

--- a/src/bls12_381/ec/g2.rs
+++ b/src/bls12_381/ec/g2.rs
@@ -140,6 +140,31 @@ impl EncodedPoint for G2Uncompressed {
     }
 }
 
+/// A struct holding the data of a compressed serialization of a [G2Affine].
+/// Use this to encode or decode [G2Affine]s using the compressed encoding.
+///
+/// # Examples
+///
+/// Encoding:
+///
+/// ```
+/// # use groupy::{CurveAffine, EncodedPoint};
+/// # use paired::bls12_381::{G2Affine};
+/// # let p = G2Affine::zero();
+/// use paired::bls12_381::G2Compressed;
+///
+/// let bytes = G2Compressed::from_affine(p).as_ref();
+/// ```
+///
+/// Decoding:
+///
+/// ```
+/// # use groupy::{EncodedPoint};
+/// use paired::bls12_381::G2Compressed;
+///
+/// let bytes: [u8; 96] = [130,245,211,210,222,77,177,157,64,166,152,14,138,163,120,66,160,229,93,29,240,107,214,139,221,200,214,0,2,232,233,89,235,156,250,54,139,60,27,119,209,143,2,165,79,224,71,184,15,9,137,49,95,131,177,42,116,253,134,121,196,241,42,174,134,234,246,171,86,144,179,79,31,221,213,14,227,204,111,108,223,89,233,85,38,213,165,216,42,170,132,250,111,24,30,66];
+/// let p = G2Compressed::from_bytes_unchecked(bytes).into_affine().unwrap();
+/// ```
 #[derive(Copy, Clone)]
 pub struct G2Compressed([u8; 96]);
 
@@ -152,7 +177,9 @@ impl fmt::Debug for G2Compressed {
 }
 
 impl G2Compressed {
-    fn from_bytes_unchecked(original: [u8; 96]) -> Self {
+    /// Creates an instance from raw bytes.
+    /// The input is not checked to contain a valid point.
+    pub fn from_bytes_unchecked(original: [u8; 96]) -> Self {
         Self(original)
     }
 }

--- a/src/bls12_381/ec/g2.rs
+++ b/src/bls12_381/ec/g2.rs
@@ -151,8 +151,8 @@ impl fmt::Debug for G2Compressed {
     }
 }
 
-impl From<[u8; 96]> for G2Compressed {
-    fn from(original: [u8; 96]) -> Self {
+impl G2Compressed {
+    fn from_bytes_unchecked(original: [u8; 96]) -> Self {
         Self(original)
     }
 }
@@ -934,7 +934,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn g2_compressed_constructor() {
+    fn g2_compressed_from_bytes_unchecked() {
         let data: [u8; 96] = [
             130, 245, 211, 210, 222, 77, 177, 157, 64, 166, 152, 14, 138, 163, 120, 66, 160, 229,
             93, 29, 240, 107, 214, 139, 221, 200, 214, 0, 2, 232, 233, 89, 235, 156, 250, 54, 139,
@@ -943,7 +943,8 @@ mod tests {
             14, 227, 204, 111, 108, 223, 89, 233, 85, 38, 213, 165, 216, 42, 170, 132, 250, 111,
             24, 30, 66,
         ];
-        let _compressed = G2Compressed::from(data);
+        let compressed = G2Compressed::from_bytes_unchecked(data);
+        assert_eq!(&compressed.0[..], &data[..]);
     }
 
     #[test]

--- a/src/bls12_381/ec/g2.rs
+++ b/src/bls12_381/ec/g2.rs
@@ -151,6 +151,12 @@ impl fmt::Debug for G2Compressed {
     }
 }
 
+impl From<[u8; 96]> for G2Compressed {
+    fn from(original: [u8; 96]) -> Self {
+        Self(original)
+    }
+}
+
 impl EncodedPoint for G2Compressed {
     type Affine = G2Affine;
 
@@ -926,6 +932,19 @@ impl OsswuMap for G2 {
 mod tests {
     use super::super::util::check_g_prime;
     use super::*;
+
+    #[test]
+    fn g2_compressed_constructor() {
+        let data: [u8; 96] = [
+            130, 245, 211, 210, 222, 77, 177, 157, 64, 166, 152, 14, 138, 163, 120, 66, 160, 229,
+            93, 29, 240, 107, 214, 139, 221, 200, 214, 0, 2, 232, 233, 89, 235, 156, 250, 54, 139,
+            60, 27, 119, 209, 143, 2, 165, 79, 224, 71, 184, 15, 9, 137, 49, 95, 131, 177, 42, 116,
+            253, 134, 121, 196, 241, 42, 174, 134, 234, 246, 171, 86, 144, 179, 79, 31, 221, 213,
+            14, 227, 204, 111, 108, 223, 89, 233, 85, 38, 213, 165, 216, 42, 170, 132, 250, 111,
+            24, 30, 66,
+        ];
+        let _compressed = G2Compressed::from(data);
+    }
 
     #[test]
     fn g2_generator() {


### PR DESCRIPTION
Closes #17
Closes #23

This is an alternative to #23. It is probably a bit more idiomatic and keeps `G1Compressed`/`G2Compressed`'s data internal.